### PR TITLE
Add CI Build

### DIFF
--- a/.github/workflow/mail.yml
+++ b/.github/workflow/mail.yml
@@ -1,0 +1,21 @@
+name: CI Build
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: wpilib/roborio-cross-ubuntu:2024-22.04
+    steps:
+    - uses: actions/checkout@v4
+    - name: Add repository to git safe directories
+      run: git config --global --add safe.directory $GITHUB_WORKSPACE
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Compile and run tests on robot code
+      id: build
+      run: ./gradlew build


### PR DESCRIPTION
Add CI Build using GitHub Actions, following these steps: https://docs.wpilib.org/en/stable/docs/software/advanced-gradlerio/robot-code-ci.html

This check will fail if the robot code doesn't build